### PR TITLE
Add Facility To Specify Input .yml Filename On Command Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Generated Dockerfiles are all based on [Phusion's Base Image](https://github.com
 To generate a Dockerfile, simply run the following command from any directory containing `Dockerfile.yml`:
 
     dockerfile.rb
+
+Optionally you can put the name of a target .yml file on the command line:
+
+    dockerfile.rb Dockerfile.someOtherFile.yml
     
 The generated Dockerfile will be output to stdout. To save it as a Dockerfile:
 

--- a/dockerfile.rb
+++ b/dockerfile.rb
@@ -1296,6 +1296,20 @@ end
 class Main
 
   def initialize(argv)
+    # Defaults
+    @inputFileName = "Dockerfile.yml"
+
+    # Handle any arguments
+    puts argv.length
+    puts argv.to_s
+    if argv.length > 1
+        puts "Error: 1 or 0 arguments expected."
+        puts "Usage: dockerfile.rb [target-dockerfile.yml]"
+        throw "Too many arguments"
+    end
+    if argv.length == 1
+        @inputFileName = argv[0]
+    end
 
     # Parse apps first so the manager can create the proper run scripts
     # Parse environment variables next so they can be substituted into strings.
@@ -1338,7 +1352,7 @@ class Main
   end
 
   def run
-    yaml = YAML::load_file("Dockerfile.yml").downcase
+    yaml = YAML::load_file(@inputFileName).downcase
     manager = Manager.new
     parser = Parser.new(yaml, manager)
     @commands.each{|command| parser.parse(command)}


### PR DESCRIPTION
If you have only one Dockerfile to deal with a single source
Dockerfile.yml will work OK.  I have the (possibly bad) habit of
labelling my Dockerfiles with names.  I would like to do the same with
my Dockerfile.yml files.

Add some crude command line handling.  0 arguments preserves existing
behavior of using Dockerfile.yml.  If 1 argument is provided, treat that
as the input .yml file name.  If more than 1 argument is provided, print
and error, give expected usage and throw an exception stating that "Too
many arguments" have been provided.

Add a bit in the README.md to show this new feature.

I could include the Dockerfile.apt-cacher-ng.yml I now have in this push
and update the README.md to show how to generate your own apt-cacher-ng
Docker Image for use, but that feels like a separate commit.